### PR TITLE
Version 0.0.3: Jetson AGX Orin support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nvidia Jetson Nano Prometheus Node Exporter (incl. GPU)
+# Nvidia Jetson Prometheus Node Exporter (incl. GPU) - no including AGX Orin platform
 
 This project contains a node exporter variation building on jetson-stats (jtop) rather than tegrastats directly.
 We export the following metrics: 
@@ -20,7 +20,7 @@ Wheels or binaries are provided here: [Jetson Stats Node Exporter Releases](http
 
 Installation with pip (no venv or conda due to jetson-stats dependency!): 
 ```
-> export JSN_RELEASE="0.0.2"
+> export JSN_RELEASE="0.0.3"
 > sudo -H pip3 install -U https://github.com/laminair/jetson_stats_node_exporter/releases/download/$JSN_RELEASE/jetson_stats_node_exporter-$JSN_RELEASE-py3-none-any.whl
 ```
 
@@ -30,6 +30,15 @@ Manual installation (may require sudo privileges due to jetson-stats dependency)
 > cd jetson_stats_node_exporter
 > python3 setup.py install
 ```
+
+## Running the exporter
+After installation the project is available as python module. Run it as follows:
+```
+python3 -m jetson_node_exporter
+```
+
+This will spawn a prometheus node exporter service on port 9100 and you'll be able to scrape all statistics.
+Note: The command above can also be run as a systemd service in the background.
 
 ## Credits
 This project is based on https://github.com/lipovsek/jetson_prometheus_exporter, which uses tegrastats.

--- a/jetson_stats_node_exporter/__main__.py
+++ b/jetson_stats_node_exporter/__main__.py
@@ -9,7 +9,7 @@ from .exporter import JetsonExporter
 from .logger import factory
 
 
-def start_exporter(port=9100, update_period=10, logfile_cleanup_interval_hours=24):
+def start_exporter(port=9100, update_period=1, logfile_cleanup_interval_hours=24):
     logger = factory(__name__)
     logger.info(f"Node exporter running on port {port}. Querying speed: {update_period}s. "
                 f"Cleanup frequency: {logfile_cleanup_interval_hours}")

--- a/jetson_stats_node_exporter/jtop_stats.py
+++ b/jetson_stats_node_exporter/jtop_stats.py
@@ -15,11 +15,11 @@ class JtopObservable(object):
             "stats": self.jetson.stats,
             "board": self.jetson.board,
             "cpu": self.jetson.cpu,
-            "mem": self.jetson.ram,
+            "mem": self.jetson.memory,
             "gpu": self.jetson.gpu,
-            "iram": self.jetson.iram,
+            # "iram": self.jetson.iram,
             "pwr": self.jetson.power,
-            "swp": self.jetson.swap,
+            # "swp": self.jetson.swap,
             "tmp": self.jetson.temperature,
             "upt": self.jetson.uptime
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jetson-stats
+jetson-stats==4.2.2
 schedule==0.6.0
 prometheus-client==0.7.1
 psutil==5.6.7

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,15 @@ import setuptools
 
 setuptools.setup(
       name='jetson_stats_node_exporter',
-      version='0.0.2',
-      description='Prometheus Node Exporter for Nvidia Jetson Devices running Jetson Stats',
+      version='0.0.3',
+      description='Prometheus Node Exporter for Nvidia Jetson Devices running Jetson Stats (now including AGX Orin)',
       author='HW.',
       author_email='herbert.woisetschlaeger@tum.de',
       url='https://www.cs.cit.tum.de/dis/team/herbert-woisetschlaeger/',
       license="GNU GPL",
       packages=["jetson_stats_node_exporter"],
       install_requires=[
-            "jetson-stats==3.1.4",
+            "jetson-stats==4.2.2",
             "schedule==1.0.0",
             "prometheus-client==0.15.0",
             "psutil==5.9.4",


### PR DESCRIPTION
This version now includes the most recent jetson-stats compatibility and runs on modern Nvidia Jetson AGX Orin devices.