### PR TITLE
Quick fix for systemd unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ Place the following file in path `/etc/systemd/system/jetson-stats-node-exporter
 ```
 [Unit]
 Description=Jetson Stats GPU Node Exporter
-After=network.target
+After=multi-user.target
+Requires=jtop.service
 
 [Service]
 Type=simple
 Restart=on-failure
+RestartSec=10
 User=root
 Group=root
 ExecStart=/usr/bin/python3 -m jetson_stats_node_exporter


### PR DESCRIPTION
* Require the jtop.service systemd unit to be started first. 
* Add a 10s delay to restart time to prevent fast cycling in case of jtop connection error on boot, or jtop failure. 

Tested on Jetpack 5.1.2 and 5.1.3.