### PR TITLE
Update unit prefixes in exporter.py

### DIFF
--- a/jetson_stats_node_exporter/exporter.py
+++ b/jetson_stats_node_exporter/exporter.py
@@ -134,7 +134,7 @@ class JetsonExporter(object):
     def __integrated_power_machine_parts(self):
         power_gauge = GaugeMetricFamily(
             name="integrated_power",
-            documentation="Power Statistics from internal power sensors (unit: mW/V/A)",
+            documentation="Power Statistics from internal power sensors (unit: mW/mV/mA)",
             labels=["statistic", "machine_part", "system_critical"]
         )
 


### PR DESCRIPTION
I think the unit prefixis were not correct. Have a look on the following data from the exporter: "
# HELP integrated_power Power Statistics from internal power sensors (unit: mW/V/A) # TYPE integrated_power gauge
integrated_power{statistic="voltage"} 4984.0
integrated_power{statistic="current"} 128.0
integrated_power{statistic="critical"} 32760.0
integrated_power{statistic="power"} 637.0"