### PR TITLE
Fixed: cannot apply command line parameters when starting container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,6 @@ RUN pip3 install -U https://github.com/laminair/jetson_stats_node_exporter/archi
 
 
 # Set the start command
-CMD ["python3", "-m", "jetson_stats_node_exporter"]
+ENTRYPOINT ["python3", "-m", "jetson_stats_node_exporter"]
+
+CMD []


### PR DESCRIPTION
The docker image doesn't support extra command line parameters like "--port", see below.

`docker run -d   --restart always   --name jetson_stats_node_exporter   -p 9101:9101   -v /run/jtop.sock:/run/jtop.sock  magiccpp1/jetson_stats_node_exporter:v0.1.1 --port 9101`
`FATA[0000] failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "--port": executable file not found in $PATH: unknown`

Minor update on Dockerfile could enable the command line parameters and we are able to change the port while running the image.